### PR TITLE
Raise memory limit of Naisjob

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -12,7 +12,7 @@ spec:
   ttlSecondsAfterFinished: 300
   resources:
     limits:
-      memory: 2Gi
+      memory: 4Gi
       cpu: "5"
     requests:
       cpu: "500m"


### PR DESCRIPTION
The job got OOMKilled, raising the limit should prevent this.

Internal-ref: [DPSKY-990]

[DPSKY-990]: https://statistics-norway.atlassian.net/browse/DPSKY-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ